### PR TITLE
Cleanup / Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs

--- a/HydrateOrDiedrate/src/Commands/AquiferCommands.cs
+++ b/HydrateOrDiedrate/src/Commands/AquiferCommands.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+using static HydrateOrDiedrate.HydrateOrDiedrateModSystem;
+
+namespace HydrateOrDiedrate.src.Commands
+{
+    public static class AquiferCommands
+    {
+        public static void Register(ICoreServerAPI api)
+        {
+            api.ChatCommands.Create("clearaquiferdata")
+                .WithDescription("Clears all saved aquifer data")
+                .RequiresPrivilege(Privilege.controlserver)
+                .HandleWith(static args =>
+                {
+                    if(HydrateOrDiedrateGlobals.AquiferManager == null) return TextCommandResult.Error("Aquifer system is not initialized.");
+
+                    HydrateOrDiedrateGlobals.AquiferManager.ClearAquiferData();
+                    return TextCommandResult.Success("Aquifer data has been cleared successfully.");
+                });
+        }
+
+    }
+}

--- a/HydrateOrDiedrate/src/Commands/ThirstCommands.cs
+++ b/HydrateOrDiedrate/src/Commands/ThirstCommands.cs
@@ -2,12 +2,14 @@
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
 
-namespace HydrateOrDiedrate
+namespace HydrateOrDiedrate.src.Commands
 {
     public static class ThirstCommands
     {
-        public static void Register(ICoreServerAPI api, Config.Config loadedConfig)
+        public static void Register(ICoreServerAPI api, HydrateOrDiedrate.Config.Config loadedConfig)
         {
+            if(loadedConfig.EnableThirstMechanics) return; //no need to register when thirtst is disabled
+
             api.ChatCommands
                 .Create("setthirst")
                 .WithDescription("Sets the player's thirst level.")
@@ -23,7 +25,7 @@ namespace HydrateOrDiedrate
                 .HandleWith((args) => OnSetNutriDefCommand(api, loadedConfig, args));
         }
 
-        private static TextCommandResult OnSetThirstCommand(ICoreServerAPI api, Config.Config loadedConfig, TextCommandCallingArgs args)
+        private static TextCommandResult OnSetThirstCommand(ICoreServerAPI api, HydrateOrDiedrate.Config.Config loadedConfig, TextCommandCallingArgs args)
         {
             string playerName = args[0] as string;
             float thirstValue = (float)args[1];
@@ -52,7 +54,7 @@ namespace HydrateOrDiedrate
             return TextCommandResult.Success($"Thirst set to {thirstValue} for player '{targetPlayer.PlayerName}'.");
         }
 
-        private static TextCommandResult OnSetNutriDefCommand(ICoreServerAPI api, Config.Config loadedConfig, TextCommandCallingArgs args)
+        private static TextCommandResult OnSetNutriDefCommand(ICoreServerAPI api, HydrateOrDiedrate.Config.Config loadedConfig, TextCommandCallingArgs args)
         {
             string playerName = args[0] as string;
             float nutriDeficitValue = (float)args[1];
@@ -74,12 +76,12 @@ namespace HydrateOrDiedrate
 
             var thirstBehavior = targetPlayer.Entity.GetBehavior<EntityBehaviorThirst>();
             if (thirstBehavior == null) return TextCommandResult.Error("Thirst behavior not found.");
-            
+
             thirstBehavior.HungerReductionAmount = nutriDeficitValue;
 
             return TextCommandResult.Success($"Nutrition deficit set to {nutriDeficitValue} for player '{targetPlayer.PlayerName}'.");
         }
-        
+
         private static IServerPlayer GetPlayerByName(ICoreServerAPI api, string playerName)
         {
             foreach (IServerPlayer player in api.World.AllOnlinePlayers)

--- a/HydrateOrDiedrate/src/Commands/ThirstCommands.cs
+++ b/HydrateOrDiedrate/src/Commands/ThirstCommands.cs
@@ -8,7 +8,7 @@ namespace HydrateOrDiedrate.src.Commands
     {
         public static void Register(ICoreServerAPI api, HydrateOrDiedrate.Config.Config loadedConfig)
         {
-            if(loadedConfig.EnableThirstMechanics) return; //no need to register when thirtst is disabled
+            if(!loadedConfig.EnableThirstMechanics) return; //no need to register when thirtst is disabled
 
             api.ChatCommands
                 .Create("setthirst")
@@ -49,7 +49,6 @@ namespace HydrateOrDiedrate.src.Commands
             if (thirstBehavior == null) return TextCommandResult.Error("Thirst behavior not found.");
 
             thirstBehavior.CurrentThirst = thirstValue;
-            thirstBehavior.UpdateThirstAttributes();
 
             return TextCommandResult.Success($"Thirst set to {thirstValue} for player '{targetPlayer.PlayerName}'.");
         }

--- a/HydrateOrDiedrate/src/Config/Sync/ConfigSyncPacket.cs
+++ b/HydrateOrDiedrate/src/Config/Sync/ConfigSyncPacket.cs
@@ -1,0 +1,17 @@
+﻿using ProtoBuf;
+using System.Collections.Generic;
+
+namespace HydrateOrDiedrate.src.Config.Sync;
+
+
+[ProtoContract]
+public class ConfigSyncPacket
+{
+    [ProtoMember(1)] public HydrateOrDiedrate.Config.Config ServerConfig { get; set; }
+
+    [ProtoMember(2)] public List<string> HydrationPatches { get; set; }
+
+    [ProtoMember(3)] public List<string> BlockHydrationPatches { get; set; }
+
+    [ProtoMember(4)] public List<string> CoolingPatches { get; set; }
+}

--- a/HydrateOrDiedrate/src/Config/Sync/ConfigSyncRequestPacket.cs
+++ b/HydrateOrDiedrate/src/Config/Sync/ConfigSyncRequestPacket.cs
@@ -1,0 +1,10 @@
+﻿using ProtoBuf;
+
+namespace HydrateOrDiedrate.src.Config.Sync;
+
+[ProtoContract]
+public class ConfigSyncRequestPacket
+{
+
+}
+

--- a/HydrateOrDiedrate/src/EntityBehaviourThirst.cs
+++ b/HydrateOrDiedrate/src/EntityBehaviourThirst.cs
@@ -49,8 +49,8 @@ namespace HydrateOrDiedrate
                 value = GameMath.Clamp(value, 0, HydrateOrDiedrateModSystem.LoadedConfig.MaxMovementSpeedPenalty);
                 if(_movementPenalty != value)
                 {
-                    UpdateWalkSpeed();
                     _movementPenalty = value;
+                    UpdateWalkSpeed();
                 }
             }
         }

--- a/HydrateOrDiedrate/src/EntityBehaviourThirst.cs
+++ b/HydrateOrDiedrate/src/EntityBehaviourThirst.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Cryptography.X509Certificates;
 using HydrateOrDiedrate.Config;
 using HydrateOrDiedrate.encumbrance;
 using Vintagestory.API.Common;
@@ -8,96 +9,123 @@ using Vintagestory.API.Server;
 
 namespace HydrateOrDiedrate
 {
-    public class EntityBehaviorThirst : Vintagestory.API.Common.Entities.EntityBehavior
+    public class EntityBehaviorThirst : EntityBehavior
     {
         private const float DefaultSpeedOfTime = 60f;
         private const float DefaultCalendarSpeedMul = 0.5f;
-        private float hungerReductionAmount;
-        private long lastProcessedTime = 0;
-        private float _currentThirst;
+
         private float _customThirstRate;
         private int _customThirstTicks;
-        private Config.Config _config;
-        private float _currentPenaltyAmount;
-        private int _thirstTickCounter;
-        private bool _isPenaltyApplied;
-        private float thirstCounter;
-        private int sprintCounter;
+        
+        private float thirstDelta;
+        private float thirstDamageDelta;
+        
         private long lastMoveMs;
-        private bool hasProcessedSaturation = false;
 
         public float CurrentThirst
         {
-            get => _currentThirst;
+            get => entity.WatchedAttributes.TryGetFloat("currentThirst") ?? MaxThirst;
+            set => entity.WatchedAttributes.SetFloat("currentThirst", GameMath.Clamp(value, 0, MaxThirst));
+        }
+
+        public float MaxThirst
+        {
+            get => entity.WatchedAttributes.TryGetFloat("maxThirst") ?? HydrateOrDiedrateModSystem.LoadedConfig.MaxThirst;
+            set => entity.WatchedAttributes.SetFloat("maxThirst", Math.Max(value, 0));
+        }
+
+        public float ThirstRate
+        {
+            get => entity.WatchedAttributes.GetFloat("thirstRate", HydrateOrDiedrateModSystem.LoadedConfig.ThirstDecayRate);
+            set => entity.WatchedAttributes.SetFloat("thirstRate", Math.Max(value, 0));
+        }
+
+        private float _movementPenalty;
+        public float MovementPenalty
+        {
+            get => _movementPenalty;
             set
             {
-                _currentThirst = GameMath.Clamp(value, 0, MaxThirst);
-                entity.WatchedAttributes.SetFloat("currentThirst", _currentThirst);
-                entity.WatchedAttributes.MarkPathDirty("currentThirst");
+                value = GameMath.Clamp(value, 0, HydrateOrDiedrateModSystem.LoadedConfig.MaxMovementSpeedPenalty);
+                if(_movementPenalty != value)
+                {
+                    UpdateWalkSpeed();
+                    _movementPenalty = value;
+                }
             }
         }
-        public float MaxThirst { get; set; }
-        public float BaseMaxThirst => _config.MaxThirst;
-        
+
+        public int HydrationLossDelay
+        {
+            get => entity.WatchedAttributes.GetInt("hydrationLossDelay");
+            set => entity.WatchedAttributes.SetInt("hydrationLossDelay", value);
+        }
+
+        public float HungerReductionAmount
+        {
+            get => entity.WatchedAttributes.GetFloat("hungerReductionAmount");
+            set => entity.WatchedAttributes.SetFloat("hungerReductionAmount", Math.Max((float)Math.Ceiling(value), 0f));
+        }
+
         public EntityBehaviorThirst(Entity entity) : base(entity)
         {
-            _config = HydrateOrDiedrateModSystem.LoadedConfig ?? new Config.Config();
-            MaxThirst = BaseMaxThirst;
-            LoadThirst();
-            InitializeCounters();
+            entity.WatchedAttributes.RegisterModifiedListener("currentThirst", OnCurrentThirstModified);
+            
+            //Ensuring these values are present in attributes for GUI purposes
+            MaxThirst = HydrateOrDiedrateModSystem.LoadedConfig.MaxThirst;
+            if(!HydrateOrDiedrateModSystem.LoadedConfig.EnableThirstMechanics || entity.WatchedAttributes.TryGetFloat("currentThirst") == null) CurrentThirst = MaxThirst;
         }
 
-
-        public EntityBehaviorThirst(Entity entity, Config.Config config) : base(entity)
+        private void OnCurrentThirstModified()
         {
-            _config = config;
-            MaxThirst = BaseMaxThirst;
-            LoadThirst();
-            InitializeCounters();
+            var currentThirst = CurrentThirst;
+            
+            if (currentThirst <= 0)
+            {
+                MovementPenalty = HydrateOrDiedrateModSystem.LoadedConfig.MaxMovementSpeedPenalty;
+            }
+            else if (currentThirst < HydrateOrDiedrateModSystem.LoadedConfig.MovementSpeedPenaltyThreshold)
+            {
+                MovementPenalty = HydrateOrDiedrateModSystem.LoadedConfig.MaxMovementSpeedPenalty * (1 - (currentThirst / HydrateOrDiedrateModSystem.LoadedConfig.MovementSpeedPenaltyThreshold));
+            }
+            else MovementPenalty = 0;
         }
+
         public void Reset(Config.Config newConfig)
         {
-            _config = newConfig;
-            MaxThirst = BaseMaxThirst;
-            UpdateThirstAttributes();
-        }
-
-        private void InitializeCounters()
-        {
-            _thirstTickCounter = 0;
-            _isPenaltyApplied = false;
-            thirstCounter = 0f;
-            sprintCounter = 0;
-            lastMoveMs = entity.World.ElapsedMilliseconds;
+            MaxThirst = HydrateOrDiedrateModSystem.LoadedConfig.MaxThirst;
         }
 
         public override void OnGameTick(float deltaTime)
         {
-            if (entity == null || !entity.Alive) return;
+            if (!HydrateOrDiedrateModSystem.LoadedConfig.EnableThirstMechanics || !entity.Alive || entity is not EntityPlayer playerEntity) return;
 
-            var player = entity as EntityPlayer;
-            if (player?.Player?.WorldData?.CurrentGameMode is EnumGameMode.Creative or EnumGameMode.Spectator or EnumGameMode.Guest)
+            if (playerEntity.Player?.WorldData?.CurrentGameMode is EnumGameMode.Creative or EnumGameMode.Spectator or EnumGameMode.Guest) return;
+
+            thirstDelta += deltaTime;
+            if (thirstDelta > 10)
             {
-                return;
+                HandleAccumulatedThirstDecay(thirstDelta);
+                thirstDelta = 0;
             }
 
-            if (entity.GetBehavior<EntityBehaviorThirst>() == null) return;
-
-            thirstCounter += deltaTime;
-            if (thirstCounter > 10f)
+            if(CurrentThirst <= 0)
             {
-                HandleThirstDecay(deltaTime);
-                thirstCounter = 0f;
-                sprintCounter = 0;
-            }
+                thirstDamageDelta += deltaTime;
 
-            ApplyThirstEffects();
+                if (thirstDamageDelta > 10)
+                {
+                    ApplyDamage();
+
+                    thirstDamageDelta -= 10f;
+                }
+            }
         }
 
-        private void HandleThirstDecay(float deltaTime)
+        private void HandleAccumulatedThirstDecay(float deltaTime)
         {
-            float thirstDecayRate = _customThirstTicks > 0 ? _customThirstRate : _config.ThirstDecayRate;
-            int hydrationLossDelay = (int)Math.Floor(entity.WatchedAttributes.GetFloat("hydrationLossDelay", 0));
+            float thirstDecayRate = _customThirstTicks > 0 ? _customThirstRate : HydrateOrDiedrateModSystem.LoadedConfig.ThirstDecayRate;
+            int hydrationLossDelay = HydrationLossDelay;
 
             float currentSpeedOfTime = entity.Api.World.Calendar.SpeedOfTime;
             float currentCalendarSpeedMul = entity.Api.World.Calendar.CalendarSpeedMul;
@@ -106,46 +134,42 @@ namespace HydrateOrDiedrate
 
             if (hydrationLossDelay > 0)
             {
-                hydrationLossDelay -= Math.Max(1, (int)Math.Floor(multiplierPerGameSec));
-                entity.WatchedAttributes.SetFloat("hydrationLossDelay", hydrationLossDelay);
+                HydrationLossDelay = hydrationLossDelay - Math.Max(1, (int)Math.Floor(multiplierPerGameSec * deltaTime));
                 return;
             }
 
-            var player = entity as EntityPlayer;
-            if (player != null)
+            if (entity is EntityPlayer player)
             {
                 if (player.Controls?.Sprint == true)
                 {
-                    thirstDecayRate *= _config.SprintThirstMultiplier;
-                    sprintCounter++;
+                    thirstDecayRate *= HydrateOrDiedrateModSystem.LoadedConfig.SprintThirstMultiplier;
                 }
 
-                if (player.Controls.TriesToMove || player.Controls.Jump || player.Controls.LeftMouseDown ||
-                    player.Controls.RightMouseDown)
+                if (player.Controls.TriesToMove || player.Controls.Jump || player.Controls.LeftMouseDown || player.Controls.RightMouseDown)
                 {
                     lastMoveMs = entity.World.ElapsedMilliseconds;
                 }
             }
 
-            if (_config.HarshHeat)
+            if (HydrateOrDiedrateModSystem.LoadedConfig.HarshHeat)
             {
-                var climate =
-                    entity.World.BlockAccessor.GetClimateAt(entity.ServerPos.AsBlockPos, EnumGetClimateMode.NowValues);
-                if (climate.Temperature > _config.TemperatureThreshold)
+                var climate = entity.World.BlockAccessor.GetClimateAt(entity.ServerPos.AsBlockPos, EnumGetClimateMode.NowValues);
+
+                if (climate.Temperature > HydrateOrDiedrateModSystem.LoadedConfig.TemperatureThreshold)
                 {
-                    float temperatureDifference = climate.Temperature - _config.TemperatureThreshold;
-                    float temperatureFactor = _config.ThirstIncreasePerDegreeMultiplier *
-                                              (float)Math.Exp(_config.HarshHeatExponentialGainMultiplier *
+                    float temperatureDifference = climate.Temperature - HydrateOrDiedrateModSystem.LoadedConfig.TemperatureThreshold;
+                    float temperatureFactor = HydrateOrDiedrateModSystem.LoadedConfig.ThirstIncreasePerDegreeMultiplier *
+                                              (float)Math.Exp(HydrateOrDiedrateModSystem.LoadedConfig.HarshHeatExponentialGainMultiplier *
                                                               temperatureDifference);
-                    
+
                     thirstDecayRate += temperatureFactor;
 
                     float coolingFactor = entity.WatchedAttributes.GetFloat("currentCoolingHot", 0f);
                     float coolingEffect = coolingFactor * (1f / (1f + (float)Math.Exp(-0.5f * temperatureDifference)));
-                    thirstDecayRate -= Math.Min(coolingEffect, thirstDecayRate - _config.ThirstDecayRate);
+                    thirstDecayRate -= Math.Min(coolingEffect, thirstDecayRate - HydrateOrDiedrateModSystem.LoadedConfig.ThirstDecayRate);
                 }
             }
-            thirstDecayRate = Math.Min(thirstDecayRate, _config.ThirstDecayRate * _config.ThirstDecayRateMax);
+            thirstDecayRate = Math.Min(thirstDecayRate, HydrateOrDiedrateModSystem.LoadedConfig.ThirstDecayRate * HydrateOrDiedrateModSystem.LoadedConfig.ThirstDecayRateMax);
 
             if (currentSpeedOfTime > DefaultSpeedOfTime || currentCalendarSpeedMul > DefaultCalendarSpeedMul)
             {
@@ -159,55 +183,16 @@ namespace HydrateOrDiedrate
             }
 
             if (_customThirstTicks > 0) _customThirstTicks--;
-            ModifyThirst(-thirstDecayRate * deltaTime);
-            UpdateThirstRate(thirstDecayRate);
+            ModifyThirst(-thirstDecayRate * deltaTime * 0.1f);
+            
+            ThirstRate = thirstDecayRate;
         }
 
-
-        private void ApplyThirstEffects()
-        {
-            _thirstTickCounter++;
-
-            if (_thirstTickCounter >= 250)
-            {
-                if (CurrentThirst <= 0)
-                {
-                    ApplyDamage();
-                    ApplyMovementSpeedPenalty(_config.MaxMovementSpeedPenalty);
-                }
-                else if (CurrentThirst < _config.MovementSpeedPenaltyThreshold)
-                {
-                    float penaltyAmount = _config.MaxMovementSpeedPenalty * (1 - (CurrentThirst / _config.MovementSpeedPenaltyThreshold));
-                    ApplyMovementSpeedPenalty(penaltyAmount);
-                }
-                else
-                {
-                    RemoveMovementSpeedPenalty();
-                }
-
-                _thirstTickCounter = 0;
-            }
-        }
-
-        public void SetInitialThirst()
-        {
-            CurrentThirst = MaxThirst;
-            UpdateThirstAttributes();
-            RemoveMovementSpeedPenalty();
-        }
-
-        public void ResetThirstOnRespawn()
+        public void OnRespawn()
         {
             CurrentThirst = 0.5f * MaxThirst;
-            hungerReductionAmount = 0;
-            entity.WatchedAttributes.SetFloat("hungerReductionAmount", hungerReductionAmount);
-            entity.WatchedAttributes.MarkPathDirty("hungerReductionAmount");
-
-            UpdateThirstAttributes();
-            RemoveMovementSpeedPenalty();
-            InitializeCounters();
+            HungerReductionAmount = 0;
         }
-
 
         private void ApplyDamage()
         {
@@ -215,156 +200,30 @@ namespace HydrateOrDiedrate
             {
                 Source = EnumDamageSource.Internal,
                 Type = EnumDamageType.Injury
-            }, _config.ThirstDamage);
+            }, HydrateOrDiedrateModSystem.LoadedConfig.ThirstDamage);
         }
 
-        private void ApplyMovementSpeedPenalty(float penaltyAmount)
-        {
-            if (_currentPenaltyAmount == penaltyAmount && _isPenaltyApplied) return;
-
-            _currentPenaltyAmount = penaltyAmount;
-            UpdateWalkSpeed();
-            _isPenaltyApplied = true;
-        }
-
-        private void RemoveMovementSpeedPenalty()
-        {
-            if (_currentPenaltyAmount == 0f && !_isPenaltyApplied) return;
-
-            _currentPenaltyAmount = 0f;
-            UpdateWalkSpeed();
-            _isPenaltyApplied = false;
-        }
-
-        private void UpdateWalkSpeed()
-        {
-            var liquidEncumbrance = entity.GetBehavior<EntityBehaviorLiquidEncumbrance>();
-            if (liquidEncumbrance != null && liquidEncumbrance.IsPenaltyApplied)
-            {
-                entity.Stats.Set("walkspeed", "thirstPenalty", -_currentPenaltyAmount, true);
-                return;
-            }
-
-            entity.Stats.Set("walkspeed", "thirstPenalty", -_currentPenaltyAmount, true);
-        }
+        private void UpdateWalkSpeed() => entity.Stats.Set("walkspeed", "thirstPenalty", -MovementPenalty, true);
 
         public void ApplyCustomThirstRate(float rate, int ticks)
         {
+            //TODO is this maybe used by other mods?
             _customThirstRate = rate;
             _customThirstTicks = ticks;
-        }
-
-        public void LoadThirst()
-        {
-            _currentThirst = entity.WatchedAttributes.GetFloat("currentThirst", MaxThirst);
-            hungerReductionAmount = entity.WatchedAttributes.GetFloat("hungerReductionAmount", 0);
-            if (hungerReductionAmount < 0)
-            {
-                hungerReductionAmount = 0;
-                entity.WatchedAttributes.SetFloat("hungerReductionAmount", hungerReductionAmount);
-                entity.WatchedAttributes.MarkPathDirty("hungerReductionAmount");
-            }
-
-            UpdateThirstAttributes();
-        }
-
-
-        public void UpdateThirstAttributes()
-        {
-            entity.WatchedAttributes.SetFloat("currentThirst", CurrentThirst);
-            entity.WatchedAttributes.SetFloat("maxThirst", MaxThirst);
-            entity.WatchedAttributes.SetFloat("normalThirstRate", _config.ThirstDecayRate);
-            entity.WatchedAttributes.MarkPathDirty("currentThirst");
-            entity.WatchedAttributes.MarkPathDirty("maxThirst");
-            entity.WatchedAttributes.MarkPathDirty("normalThirstRate");
-        }
-
-        public static void UpdateThirstOnServerTick(IServerPlayer player, float deltaTime, Config.Config config)
-        {
-            if (player?.Entity == null || !player.Entity.WatchedAttributes.GetBool("isFullyInitialized") || !player.Entity.Alive) return;
-
-            var gameMode = player.WorldData.CurrentGameMode;
-            if (gameMode == EnumGameMode.Creative || gameMode == EnumGameMode.Spectator || gameMode == EnumGameMode.Guest) return;
-
-            var thirstBehavior = player.Entity.GetBehavior<EntityBehaviorThirst>();
-            if (thirstBehavior != null)
-            {
-                thirstBehavior.OnGameTick(deltaTime);
-            }
-            else
-            {
-                if (TryAddThirstBehavior(player.Entity, config))
-                {
-                    thirstBehavior = player.Entity.GetBehavior<EntityBehaviorThirst>();
-                    thirstBehavior?.OnGameTick(deltaTime);
-                }
-            }
-        }
-
-        public void UpdateThirstRate(float rate)
-        {
-            entity.WatchedAttributes.SetFloat("thirstRate", rate);
-            entity.WatchedAttributes.MarkPathDirty("thirstRate");
-        }
-
-        public void ApplyHydrationLossDelay(float hydLossDelay)
-        {
-            int roundedHydLossDelay = (int)Math.Floor(hydLossDelay);
-            entity.WatchedAttributes.SetFloat("hydrationLossDelay", roundedHydLossDelay);
-            entity.WatchedAttributes.MarkPathDirty("hydrationLossDelay");
         }
 
         public void ModifyThirst(float amount, float hydLossDelay = 0)
         {
             CurrentThirst += amount;
 
-            int currentHydrationLossDelay = (int)Math.Floor(entity.WatchedAttributes.GetFloat("hydrationLossDelay", 0));
+            int hydrationLossDelay = HydrationLossDelay;
 
-            if (hydLossDelay > currentHydrationLossDelay)
+            if (hydLossDelay > hydrationLossDelay)
             {
-                ApplyHydrationLossDelay(hydLossDelay);
+                HydrationLossDelay = (int)Math.Floor(hydLossDelay);
             }
         }
 
-        private static bool TryAddThirstBehavior(Entity entity, Config.Config config)
-        {
-            try
-            {
-                var thirstBehavior = new EntityBehaviorThirst(entity, config);
-                entity.AddBehavior(thirstBehavior);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        public float HungerReductionAmount
-        {
-            get => hungerReductionAmount;
-            set
-            {
-                hungerReductionAmount = (float)Math.Ceiling(value);
-                entity.WatchedAttributes.SetFloat("hungerReductionAmount", hungerReductionAmount);
-                entity.WatchedAttributes.MarkPathDirty("hungerReductionAmount");
-            }
-        }
-
-        public bool HasProcessedSaturation
-        {
-            get => hasProcessedSaturation;
-            set
-            {
-                hasProcessedSaturation = value;
-                if (value)
-                {
-                    lastProcessedTime = entity.World.ElapsedMilliseconds;
-                }
-                entity.WatchedAttributes.SetBool("hasProcessedSaturation", hasProcessedSaturation);
-                entity.WatchedAttributes.MarkPathDirty("hasProcessedSaturation");
-            }
-        }
         public override string PropertyName() => "thirst";
     }
 }

--- a/HydrateOrDiedrate/src/HUD/HudElementThirstBar.cs
+++ b/HydrateOrDiedrate/src/HUD/HudElementThirstBar.cs
@@ -2,34 +2,34 @@
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
 
-namespace HydrateOrDiedrate.HUD
-{
+namespace HydrateOrDiedrate.HUD;
+
 public class HudElementThirstBar : HudElement
 {
-private GuiElementStatbar _statbar;
-private bool isFlashing;
-public bool showThirstBar = true;
+    private GuiElementStatbar _statbar;
+    private bool isFlashing;
+    public bool showThirstBar = true;
     public override double InputOrder => 1.0;
-
+    
     public HudElementThirstBar(ICoreClientAPI capi) : base(capi)
     {
         ComposeGuis();
         capi.Event.RegisterGameTickListener(OnGameTick, 100);
         capi.Event.RegisterGameTickListener(OnFlashStatbars, 1200);
     }
-
+    
     public void OnGameTick(float dt)
     {
         UpdateThirst();
     }
-
+    
     private void OnFlashStatbars(float dt)
     {
         if (_statbar == null) return;
-
+    
         var currentThirst = capi.World.Player.Entity.WatchedAttributes.GetFloat("currentThirst");
         var maxThirst = capi.World.Player.Entity.WatchedAttributes.GetFloat("maxThirst");
-
+    
         if (currentThirst < maxThirst * 0.2f)
         {
             isFlashing = !isFlashing;
@@ -40,28 +40,28 @@ public bool showThirstBar = true;
             _statbar.ShouldFlash = false;
         }
     }
-
+    
     private void UpdateThirst()
     {
         if (_statbar == null) return;
-
+    
         var currentThirst = capi.World.Player.Entity.WatchedAttributes.GetFloat("currentThirst");
         var maxThirst = capi.World.Player.Entity.WatchedAttributes.GetFloat("maxThirst");
         
         float lineInterval = Math.Max(100f, maxThirst / 100f);
-
+    
         _statbar.SetValues(currentThirst, 0.0f, maxThirst);
         _statbar.SetLineInterval(lineInterval);
     }
-
-
+    
+    
     private void ComposeGuis()
     {
         const float statsBarParentWidth = 850f;
         const float statsBarWidth = statsBarParentWidth * 0.41f;
-
+    
         double[] thirstBarColor = { 0, 0.4, 0.5, 0.5 };
-
+    
         var statsBarBounds = new ElementBounds()
         {
             Alignment = EnumDialogArea.CenterBottom,
@@ -69,51 +69,50 @@ public bool showThirstBar = true;
             fixedWidth = statsBarParentWidth,
             fixedHeight = 100
         }.WithFixedAlignmentOffset(0.0, 5.0);
-
+    
         var isRight = true;
         var alignmentOffsetX = isRight ? -2.0 : 1.0;
-
+    
         var thirstBarBounds = ElementStdBounds.Statbar(isRight ? EnumDialogArea.RightTop : EnumDialogArea.LeftTop, statsBarWidth)
             .WithFixedAlignmentOffset(alignmentOffsetX, -16)
             .WithFixedHeight(10);
-
+    
         var thirstBarParentBounds = statsBarBounds.FlatCopy().FixedGrow(0.0, 20.0);
-
+    
         var composer = capi.Gui.CreateCompo("thirststatbar", thirstBarParentBounds);
-
+    
         _statbar = new GuiElementStatbar(composer.Api, thirstBarBounds, thirstBarColor, isRight, false);
-
+    
         composer
             .BeginChildElements(statsBarBounds)
             .AddInteractiveElement(_statbar, "thirststatsbar")
             .EndChildElements()
             .Compose();
-
+    
         Composers["thirstbar"] = composer;
-
+    
         TryOpen();
     }
-
+    
     public override void OnOwnPlayerDataReceived()
     {
         ComposeGuis();
         UpdateThirst();
     }
-
+    
     public override void OnRenderGUI(float deltaTime)
     {
         if (!HydrateOrDiedrateModSystem.LoadedConfig.EnableThirstMechanics) return;
-
+    
         if (capi.World.Player.WorldData.CurrentGameMode == EnumGameMode.Spectator) return;
-
+    
         base.OnRenderGUI(deltaTime);
     }
-
-
+    
+    
     public override bool TryClose() => false;
-
+    
     public override bool ShouldReceiveKeyboardEvents() => false;
-
+    
     public override bool Focusable => false;
-}
 }

--- a/HydrateOrDiedrate/src/XSkill/XLibSkills.cs
+++ b/HydrateOrDiedrate/src/XSkill/XLibSkills.cs
@@ -78,7 +78,6 @@ namespace HydrateOrDiedrate.XSkill
             float newMaxThirst = HydrateOrDiedrateModSystem.LoadedConfig.MaxThirst * multiplier;
             behavior.CurrentThirst = behavior.CurrentThirst / behavior.MaxThirst * newMaxThirst;
             behavior.MaxThirst = newMaxThirst;
-            behavior.UpdateThirstAttributes();
         }
 
         private void OnEquatidian(PlayerAbility playerAbility, int oldTier)

--- a/HydrateOrDiedrate/src/patches/CharacterExtraDialogsPatch.cs
+++ b/HydrateOrDiedrate/src/patches/CharacterExtraDialogsPatch.cs
@@ -192,7 +192,7 @@ namespace HydrateOrDiedrate.patches
             float maxThirst = entity.WatchedAttributes.GetFloat("maxThirst", 1500f);
             float thirstPenalty = entity.WatchedAttributes.GetFloat("thirstPenalty", 0f);
             float currentThirstRate = entity.WatchedAttributes.GetFloat("thirstRate", 0.01f);
-            float normalThirstRate = entity.WatchedAttributes.GetFloat("normalThirstRate", 0.01f);
+            float normalThirstRate = HydrateOrDiedrateModSystem.LoadedConfig.ThirstDecayRate;
             float thirstRatePercentage = (currentThirstRate / normalThirstRate) * 100;
             thirstRatePercentage = Math.Max(0, thirstRatePercentage);
             var thirstDynamicText = compo.GetDynamicText("hydrateordiedrate_thirst");

--- a/HydrateOrDiedrate/src/patches/OnEntityReceiveSaturationPatch.cs
+++ b/HydrateOrDiedrate/src/patches/OnEntityReceiveSaturationPatch.cs
@@ -43,8 +43,6 @@ namespace HydrateOrDiedrate.patches
 
                         applyNutrition = false;
                     }
-
-                    thirstBehavior.HasProcessedSaturation = true;
                 }
 
                 float maxsat = __instance.MaxSaturation;


### PR DESCRIPTION
**Work done:**
- Cleaned up old code
- Simplified code
- Upgraded command (it was using obsolete registry method)
- Fixed excessive calls to MarkDirty (assigning the value already did this so all those manual calls where just overhead)
- Fixed hydration loss being affected by server tick speed (Could potentially cause massive hydration loss during server lagg spike)
- Fixed infinite increase in game tick listeners (because listeners where assigned per player in OnPlayerRespawn and also not disposed)

### **IMPORTANT NOTES:**
- The speed at which you lose hydration / take damage might be slightly different (tried to keep this similar but since original code was affected by server lagg / tps it was impossible to 100% accurately convert this to use the accumulated delta time)