### PR TITLE
Load ImGui from nuget package to avoid hardcoding DLL reference.

### DIFF
--- a/HydrateOrDiedrate/HydrateOrDiedrate.csproj
+++ b/HydrateOrDiedrate/HydrateOrDiedrate.csproj
@@ -60,16 +60,8 @@
       <HintPath>lib\configlib.dll</HintPath>
       <Private>false</Private>
     </Reference>
-    <Reference Include="VSImGui">
-      <HintPath>lib\dlls\VSImGui.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
     <Reference Include="SkiaSharp">
       <HintPath>$(VINTAGE_STORY)/Lib/SkiaSharp.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="ImGui.NET">
-      <HintPath>lib\dlls\VImGui.NET.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="xlib">
@@ -84,6 +76,10 @@
       <HintPath>$(VINTAGE_STORY)/Lib/OpenTK.dll</HintPath>
       <Private>False</Private>
     </Reference>
+  </ItemGroup>
+
+  <ItemGroup> <!-- NuGet packages -->
+      <PackageReference Include="VSImGui" Version="0.0.6" PrivateAssets="all" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since a nuget ImGui distribution is available, this seems like a preferred option, just spreading the word :3

ImGui.NET does not seem to be necessary with this change (tested with [this release](https://github.com/jayugg/NaturesCall/pull/5).