### PR TITLE
guard against invalid CollectibleObjects

### DIFF
--- a/HydrateOrDiedrate/src/Hydration/HydrationManager.cs
+++ b/HydrateOrDiedrate/src/Hydration/HydrationManager.cs
@@ -22,7 +22,7 @@ public static class HydrationManager
     public static float GetHydration(ItemStack itemStack)
     {
         var collectible = itemStack?.Collectible;
-        if (collectible is null) return 0f;
+        if (collectible?.Code is null) return 0f;
 
         if (CustomHydrationEvaluators.TryGetValue(collectible.Code, out var evaluator)) return evaluator(itemStack);
 


### PR DESCRIPTION
Guard clause to stop issues caused by invalid itemstacks

Log as provided on ModDB
```
Running on 64 bit Windows 10.0.26100.0 with 32540 MB RAM
Game Version: v1.21.1 (Stable)
2025-09-23 18:47:38: Critical error occurred in the following mod: hydrateordiedrate@2.2.16
Loaded Mods: cbr@1.0.0, chiseltools@1.15.1, claycasting@1.3.4, dyedcloth@1.0.1, decor@1.2.1, dressedtokill@1.3.0, greesblastingpowder@1.0.3, harvestice@1.0.0, honeypressmittim@1.0.2, lightlevelone@2.0.0, lumberslingcontinued@1.0.5, millwright@1.2.8, MoreShingles@0.0.3, moretreesmoreseeds@1.0.0, mycodiversity@1.0.4, spyglass@0.5.2, temporalsymphony@2.2.1, game@1.21.1, aged@2.0.1, airthermomod@0.2.0, apeflowerpots@1.3.1, apewindows@1.4.0, attributerenderinglibrary@2.3.0, egocaribautomapmarkers@4.0.3, betterfirepit@1.1.6, blacksmithenhancements@1.1.4, carryon@1.10.9, cartwrightscaravan@1.7.2, commonlib@2.8.0, configurableroomsize@1.1.0, danatweaks@3.6.0, foodshelves@2.3.0, fromgoldencombs@1.9.2-rc.2, geartolife@1.0.1, glassroof@1.1.0, hydrateordiedrate@2.2.16, jopainting@1.4.1, mannequinstand@1.0.6, millwrightvawtaddon@1.0.2, petai@4.0.0, rpvoicechat@2.3.23, smithingplus@1.8.0-rc.3, statushudcont@3.3.1, stepupadvanced@1.2.1, substrate@1.1.2, tasshroombodyfat@0.0.16, toolsmith@1.2.8, unchisel@1.1.2, variantmeals@2.5.1, discordrichpresence@1.1.1, creative@1.21.1, survival@1.21.1, shearlib@1.2.0, stonequarry@3.5.1, tabletopgames@3.0.2, wolftaming@4.0.1, wool@1.7.1
Involved Harmony IDs: com.chronolegionnaire.hydrateordiedrate, spyglass
System.ArgumentNullException: Value cannot be null. (Parameter 'key')
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at HydrateOrDiedrate.HydrationManager.GetHydration(ItemStack itemStack) in C:\Users\bryan\RiderProjects\HydrateOrDiedrate\HydrateOrDiedrate\src\Hydration\HydrationManager.cs:line 27
   at HydrateOrDiedrate.patches.CollectibleObjectGetHeldItemInfoPatch.Postfix(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, Boolean withDebugInfo) in C:\Users\bryan\RiderProjects\HydrateOrDiedrate\HydrateOrDiedrate\src\Hydration\Patches\CollectibleObjectGetHeldItemInfoPatch.cs:line 22
   at Vintagestory.API.Common.CollectibleObject.GetHeldItemInfo_Patch1(CollectibleObject this, ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, Boolean withDebugInfo)
   at Vintagestory.API.Common.Block.GetHeldItemInfo(ItemSlot inSlot, StringBuilder dsc, IWorldAccessor world, Boolean withDebugInfo) in VintagestoryApi\Common\Collectible\Block\Block.cs:line 2327
   at Vintagestory.API.Common.ItemStack.GetDescription(IWorldAccessor world, ItemSlot inSlot, Boolean debug) in VintagestoryApi\Common\Collectible\ItemStack.cs:line 402
   at Vintagestory.API.Common.ItemSlot.GetStackDescription(IClientWorldAccessor world, Boolean extendedDebugInfo) in VintagestoryApi\Common\Inventory\ItemSlot.cs:line 478
   at Vintagestory.GameContent.ItemSlotTrade.GetStackDescription(IClientWorldAccessor world, Boolean extendedDebugInfo) in VSSurvivalMod\Systems\Trading\ItemSlotTrade.cs:line 92
   at Vintagestory.Client.NoObf.HudMouseTools.OnRequireInfoText(ItemSlot slot) in VintagestoryLib\Client\Systems\Gui\Huds\HudMouseTools.cs:line 169
   at Vintagestory.API.Client.GuiElementItemstackInfo.AsyncRecompose() in VintagestoryApi\Client\UI\Elements\Impl\Interactive\Text\GuiElementItemstackInfo.cs:line 127
   at Vintagestory.API.Client.GuiElementItemstackInfo.SetSourceSlot(ItemSlot nowSlot, Boolean forceRecompose) in VintagestoryApi\Client\UI\Elements\Impl\Interactive\Text\GuiElementItemstackInfo.cs:line 254
   at Vintagestory.Client.NoObf.HudMouseTools.OnMouseEnterSlot(ItemSlot slot) in VintagestoryLib\Client\Systems\Gui\Huds\HudMouseTools.cs:line 213
   at Vintagestory.Client.NoObf.ClientEventManager.TriggerOnMouseEnterSlot(ClientMain game, ItemSlot slot) in VintagestoryLib\Client\Util\ClientEventManager.cs:line 517
   at Vintagestory.Client.NoObf.InputAPI.TriggerOnMouseEnterSlot(ItemSlot slot) in VintagestoryLib\Client\API\InputAPI.cs:line 50
   at Vintagestory.API.Client.GuiElementItemSlotGridBase.OnMouseMove(ICoreClientAPI api, MouseEvent args) in VintagestoryApi\Client\UI\Elements\Impl\Interactive\Inventory\GuiElementItemSlotGridBase.cs:line 901
   at Vintagestory.API.Client.GuiComposer.OnMouseMove(MouseEvent mouse) in VintagestoryApi\Client\UI\GuiComposer.cs:line 505
   at Vintagestory.API.Client.GuiDialog.OnMouseMove(MouseEvent args) in VintagestoryApi\Client\UI\Dialog\GuiDialog.cs:line 618
   at Vintagestory.Client.NoObf.GuiManager.OnMouseMove(MouseEvent args) in VintagestoryLib\Client\Systems\Gui\GuiManager.cs:line 447
   at Vintagestory.Client.NoObf.ClientMain.OnMouseMove_Patch0(ClientMain this, MouseEvent args)
   at Vintagestory.Client.NoObf.ClientPlatformWindows.UpdateMousePosition() in VintagestoryLib\Client\ClientPlatform\Input.cs:line 113
   at Vintagestory.Client.NoObf.ClientPlatformWindows.window_RenderFrame(FrameEventArgs e) in VintagestoryLib\Client\ClientPlatform\GameWindow.cs:line 103
   at OpenTK.Windowing.Desktop.GameWindow.Run()
   at Vintagestory.Client.ClientProgram.Start(ClientProgramArgs args, String[] rawArgs) in VintagestoryLib\Client\ClientProgram.cs:line 338
   at Vintagestory.Client.ClientProgram.<>c__DisplayClass10_0.<.ctor>b__1() in VintagestoryLib\Client\ClientProgram.cs:line 133
   at Vintagestory.ClientNative.CrashReporter.Start(ThreadStart start) in VintagestoryLib\Client\ClientPlatform\ClientNative\CrashReporter.cs:line 95
```

