### PR TITLE
Fix for well water blockentity not migrating properly

### DIFF
--- a/HydrateOrDiedrate/modinfo.json
+++ b/HydrateOrDiedrate/modinfo.json
@@ -8,7 +8,7 @@
       "TheInsanityGod"
     ],
     "description": "Adds a thirst and hot weather mechanic to the game.",
-    "version": "2.2.21",
+    "version": "2.2.22",
     "dependencies": {
         "game": "*"
     }


### PR DESCRIPTION
`ReconcileStoredVolumeWithWorld` now checks blockEntity and fixes it if broken.