### PR TITLE
Fix for occasional error due to wellwater trying to freeze

### DIFF
--- a/HydrateOrDiedrate/assets/hydrateordiedrate/blocktypes/liquid/wellwater.json
+++ b/HydrateOrDiedrate/assets/hydrateordiedrate/blocktypes/liquid/wellwater.json
@@ -43,6 +43,7 @@
     }
   ],
   "attributes": {
+    "freezable": false,
     "smothersFire": true,
     "pushVectorByType": {
       "*-n-*": { "x": 0, "y": 0, "z": -0.0015 },


### PR DESCRIPTION
stop wellwater from freezing, we don't have any frozen block or logic for wells to handle this in the first place. prevents occasional error in logs when wellwater is in perfect conditions for freezing.

```
22.11.2025 16:21:50 [Error] Exception thrown in block.OnServerGameTick() for block code 'hydrateordiedrate:wellwater-fresh-clean-natural-still-7':
22.11.2025 16:21:50 [Error] Exception: Object reference not set to an instance of an object.
   at Vintagestory.GameContent.BlockWater.OnServerGameTick(IWorldAccessor world, BlockPos pos, Object extra) in VSSurvivalMod\Block\BlockWater.cs:line 94
   at Vintagestory.Server.ServerSystemBlockSimulation.OnServerTick(Single dt) in VintagestoryLib\Server\Systems\World\BlockSimulation.cs:line 973
```

Note: doesn't appear to be fatal and only occurs under the perfect conditions meaning freezing temperature, still, height 7 and with nothing above it that stops rain (having a winch likely already stops it from happening)