### PR TITLE
Small fix to aquifer hints

### DIFF
--- a/HydrateOrDiedrate/src/Wells/Aquifer/AquiferManager.cs
+++ b/HydrateOrDiedrate/src/Wells/Aquifer/AquiferManager.cs
@@ -180,7 +180,7 @@ public static partial class AquiferManager
             }
         }
 
-        if (bestRating > currentRating)
+        if (bestRating > currentRating && bestRating > AquiferData.MinimumAquiferRatingForDetection)
         {
             int dxDir = bestChunk.X - chunkPos.X;
             int dyDir = bestChunk.Y - chunkPos.Y;


### PR DESCRIPTION
GetAquiferDirectionHint now respects MinimumAquiferRatingForDetection (so people don't think they have an aquifer nearby but it turns out to be extremely poor