### PR TITLE
fix 4 dimensional winch.

### DIFF
--- a/HydrateOrDiedrate/assets/hydrateordiedrate/blocktypes/wood/winch.json
+++ b/HydrateOrDiedrate/assets/hydrateordiedrate/blocktypes/wood/winch.json
@@ -2,7 +2,7 @@
 	"code": "winch",
 	"class": "HoD:BlockWinch",
 	"entityclass": "HoD:BlockEntityWinch",
-	"entityBehaviors": [{ "name": "MPConsumer" }],
+	"entityBehaviors": [{ "name": "MPConsumer", "properties": { "mechPartShape": null } }],
 	"behaviors": [
 		{"name": "Container"},
 		{


### PR DESCRIPTION
fix 4 dimensional winch (change in base game related to 4d quern)

Essentially `mechPartShape` is no longer null by default but instead defaults to the shape of the block, hence the duplicate rendering.