### PR TITLE
Fix for which rubber banding

### DIFF
--- a/HydrateOrDiedrate/src/Wells/Winch/BlockEntityWinch.cs
+++ b/HydrateOrDiedrate/src/Wells/Winch/BlockEntityWinch.cs
@@ -303,11 +303,6 @@ namespace HydrateOrDiedrate.Wells.Winch
                 StopTurning();
                 return;
             }
-            var sel = RotationPlayer.CurrentBlockSelection;
-            if (sel == null || !sel.Position.Equals(Pos) || sel.SelectionBoxIndex != 1)
-            {
-                StopTurning();
-            }
         }
         // Hacky fix for infinite turning glitch
 


### PR DESCRIPTION
Removed part of sanity check that was causing rubberbanding on winch depending on where you aimed.

The remainder of the sanity check should still be enough to prevent #82 