### PR TITLE
Fix potential freeze in winch renderer

### DIFF
--- a/HydrateOrDiedrate/src/Wells/Winch/WinchTopRenderer.cs
+++ b/HydrateOrDiedrate/src/Wells/Winch/WinchTopRenderer.cs
@@ -192,7 +192,14 @@ public class WinchTopRenderer : IRenderer
             prog.ProjectionMatrix = rpi.CurrentProjectionMatrix;
             rpi.RenderMultiTextureMesh(WinchTopMeshRef, "tex", 0);
 
-            lastBucketDepth = GameMath.Lerp(lastBucketDepth, Winch.BucketDepth, deltaTime * 10);
+            //Maximum amount it may overshoot (allowes the animation to be slightly ahead without becomming jittery)
+            const float maxOvershoot = 2f; 
+
+            lastBucketDepth = GameMath.Clamp(
+                GameMath.Lerp(lastBucketDepth, Winch.BucketDepth, deltaTime * 10),
+                0,
+                Winch.BucketDepth + maxOvershoot
+            );
 
             if (containerMeshRef is null)
             {


### PR DESCRIPTION
Fix potential cascade freeze caused by winch renderer overshooting target depth, should fix #174