### PR TITLE
Improvement in cooling display

### DIFF
--- a/HydrateOrDiedrate/src/Hot Weather/Patches/CollectibleBehaviorWearablePatches.cs
+++ b/HydrateOrDiedrate/src/Hot Weather/Patches/CollectibleBehaviorWearablePatches.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using HydrateOrDiedrate.Config;
 using HydrateOrDiedrate.Hot_Weather;
 using System.Collections.Generic;
 using System.Reflection.Emit;
@@ -73,8 +74,8 @@ namespace HydrateOrDiedrate.patches
             var itemStack = inSlot?.Itemstack;
             if (itemStack == null) return;
             float maxWarmth = wearableBh.GetMaxWarmth(inSlot);
-            float maxCooling = CoolingManager.GetMaxCooling(itemStack);
-            float coolingNow = wearableBh.GetCooling(inSlot);
+            float maxCooling = CoolingManager.GetMaxCooling(itemStack) * ModConfig.Instance.HeatAndCooling.CoolingTempOffsetPerPoint;
+            float coolingNow = wearableBh.GetCooling(inSlot) * ModConfig.Instance.HeatAndCooling.CoolingTempOffsetPerPoint;
 
             var warmthFormat = Lang.GetUnformatted("+{0:0.#}°C");
             var coolingFormat = Lang.GetUnformatted("hydrateordiedrate:itemwearable-temperature-format");

--- a/HydrateOrDiedrate/src/Patches/CharacterExtraDialogsPatch.cs
+++ b/HydrateOrDiedrate/src/Patches/CharacterExtraDialogsPatch.cs
@@ -284,13 +284,13 @@ public static class CharacterExtraDialogsPatch
         var hodCooling = entity.WatchedAttributes.GetTreeAttribute("hodCooling");
         if (hodCooling != null)
         {
-            float gearCooling = hodCooling.GetFloat("gearCooling", 0f);
-            float totalCooling = hodCooling.GetFloat("totalCooling", 0f);
+            float gearCooling = hodCooling.GetFloat("gearCooling", 0f) * ModConfig.Instance.HeatAndCooling.CoolingTempOffsetPerPoint;
+            float totalCooling = hodCooling.GetFloat("totalCooling", 0f) * ModConfig.Instance.HeatAndCooling.CoolingTempOffsetPerPoint;
             cached.coolingDynamicText?.SetNewText(
                 $"{gearCooling:0.##} | {totalCooling:0.##}",
                 false, false, false
             );
-
+            
             int wetBonus    = hodCooling.GetInt("wetBonus", 0);
             int roomBonus   = hodCooling.GetInt("roomBonus", 0);
             int lowSunBonus = hodCooling.GetInt("lowSunBonus", 0);


### PR DESCRIPTION
Fix clothing showing the cooling points as if they where the actual temperature, now it shows the actual temperature (respecting CoolingTempOffsetPerPoint)

And changed the cooling point display in the character menu to show it's values as actual temperature difference instead of points.